### PR TITLE
logging refactor

### DIFF
--- a/src/amo/webhooks/lead-add.webhook.ts
+++ b/src/amo/webhooks/lead-add.webhook.ts
@@ -21,5 +21,6 @@ export class LeadAddWebhook extends AbstractWebhook {
     }
 
     await Promise.all([this.telegram.textToAdmin(message), this.telegram.textToManager(message)]);
+    this.logger.log(`LEAD_ADD, lead_id: ${lead.data.id}`);
   }
 }

--- a/src/amo/webhooks/lead-status.webhook.ts
+++ b/src/amo/webhooks/lead-status.webhook.ts
@@ -40,6 +40,7 @@ export class LeadStatusWebhook extends AbstractWebhook {
     }
 
     await lead.saveToAmo();
+    this.logger.log(`LEAD_STATUS, lead_id: ${lead.data.id}, status_id: ${lead.data.source_id}`);
   }
 
   private async statusRequisite(lead: LeadHelper) {
@@ -90,6 +91,7 @@ export class LeadStatusWebhook extends AbstractWebhook {
       });
 
       lead.note("✅ email: письмо с реквизитами отправлено");
+      this.logger.log(`STATUS_REQUISITE, lead_id: ${lead.data.id}, mail sent`);
     } catch (err) {
       this.logger.error(err);
       lead.note("❌ email: ошибка при отправке письма с реквизитами");
@@ -111,6 +113,7 @@ export class LeadStatusWebhook extends AbstractWebhook {
       });
 
       lead.note("✅ email: письмо с подтверждением оплаты отправлено");
+      this.logger.log(`STATUS_PAYMENT, lead_id: ${lead.data.id}, mail sent`);
     } catch (err) {
       this.logger.error(err);
       lead.note("❌ email: ошибка при отправке письма с подтверждением оплаты");
@@ -166,6 +169,7 @@ export class LeadStatusWebhook extends AbstractWebhook {
       );
 
       lead.note(`✎ Сформирован товарный чек: ${yadisk_url}`);
+      this.logger.log(`STATUS_DELIVERY, lead_id: ${lead.data.id}, pdf: ${yadisk_url}`);
     } catch (err) {
       this.logger.error(err);
       lead.note("❌ Товарный чек: ошибка при создании");
@@ -207,6 +211,7 @@ export class LeadStatusWebhook extends AbstractWebhook {
       );
 
       lead.note(`✎ Сформирован почтовый бланк: ${yadisk_url}`);
+      this.logger.log(`STATUS_POST, lead_id: ${lead.data.id}, pdf: ${yadisk_url}`);
     } catch (err) {
       this.logger.error(err);
       lead.note("❌ Почтовый бланк: ошибка при создании");
@@ -238,6 +243,7 @@ export class LeadStatusWebhook extends AbstractWebhook {
       });
 
       lead.note("✅ email: письмо с трек-кодом отправлено");
+      this.logger.log(`STATUS_SENT, lead_id: ${lead.data.id}, mail sent`);
     } catch (err) {
       this.logger.error(err);
       lead.note("❌ email: ошибка при отправке письма с трек-кодом");
@@ -363,11 +369,15 @@ export class LeadStatusWebhook extends AbstractWebhook {
         lead.note(
           `❌ СДЭК: ошибки при создании заказа\n${res.requests[0].errors?.map((err) => err.message)}`.trim(),
         );
+        this.logger.error(
+          `STATUS_CDEK, lead_id: ${lead.data.id}, error: ${res.requests[0].errors?.map((err) => err.message)}`,
+        );
       } else {
         lead.note(
           `✎ СДЭК: создан заказ на доставку${is_pvz ? " в ПВЗ" : ""} по тарифу ${lead.custom_fields.get(AMO.CUSTOM_FIELD.DELIVERY_TARIFF) as string}`,
         );
         lead.custom_fields.set(AMO.CUSTOM_FIELD.CDEK_UUID, res.entity.uuid);
+        this.logger.log(`STATUS_CDEK, lead_id: ${lead.data.id}, cdek_uuid: ${res.entity.uuid}`);
 
         setTimeout(async () => {
           const lead_new = await this.amo.lead.getLeadById(lead.data.id);

--- a/src/cdek/webhooks/order-status.webhook.ts
+++ b/src/cdek/webhooks/order-status.webhook.ts
@@ -91,6 +91,10 @@ export class OrderStatusWebhook extends AbstractWebhook {
     }
 
     await Promise.all(promises);
+
+    this.logger.log(
+      `CDEK_ORDER_STATUS, lead_id: ${data.attributes.number}, uuid: ${data.uuid}, trackcode: ${data.attributes.cdek_number}, code: ${data.attributes.status_code}`,
+    );
   }
 
   parse(data: UpdateOrderStatus): ParsedWebhook {
@@ -293,6 +297,8 @@ export class OrderStatusWebhook extends AbstractWebhook {
       ]),
     ]);
 
+    this.logger.log(`CDEK_RETURN, lead_id: ${direct_lead_id}, uuid: ${cdek_return.entity.uuid}`);
+
     return direct_lead_id;
   }
 
@@ -376,6 +382,10 @@ export class OrderStatusWebhook extends AbstractWebhook {
         },
       ]),
     ]);
+
+    this.logger.log(
+      `CDEK_PARTIAL_RETURN, direct_id: ${direct_lead.id}, return_id: ${return_lead._embedded.leads[0].id}, return_uuid: ${cdek_return.entity.uuid}, return_trackcode: ${cdek_return.entity.cdek_number}`,
+    );
 
     return return_lead._embedded.leads[0].id;
   }

--- a/src/utils/logger.middleware.ts
+++ b/src/utils/logger.middleware.ts
@@ -27,7 +27,7 @@ export class LoggerMiddleware implements NestMiddleware {
         if (typeof value !== "string") continue;
         req.headers[key] = value.replaceAll('"', "");
       }
-      this.logger.log({
+      this.logger.debug({
         data: {
           request: {
             method: req.method,


### PR DESCRIPTION
HTTP теперь имеют уровень DEBUG

Ключевые действия по хукам амо и сдека логируются с минимальной необходимой информацией вроде `lead_id` с уровнем INFO.
Тейл лога по умолчанию будет выводить уровень INFO и выше, можно указать немобходимый уровень с помощью введённого ключа  `level`, например `--level=debug`.
Для уменьшения спама в консоле сервера необходимо изменить парметр  в`env` `LOG_LEVEL=info`. При этом в файл всё равно будет писаться всё с уровнем DEBUG и выше.

Возможно, нужно ввести логирование и других действий - добавить по мере необходимости.

Closes https://github.com/kosachev/blackhole/issues/59