### PR TITLE
add analytics module, create utm cache endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ lerna-debug.log*
 */amo_token.json
 
 .vscode
+run.ts

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "grammy": "^1.38.1",
     "handlebars": "^4.7.8",
     "imap": "^0.8.19",
+    "lru-cache": "^11.2.1",
     "nest-winston": "^1.10.2",
     "nodemailer": "^7.0.5",
     "number-to-words-ru": "^2.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       imap:
         specifier: ^0.8.19
         version: 0.8.19
+      lru-cache:
+        specifier: ^11.2.1
+        version: 11.2.1
       nest-winston:
         specifier: ^1.10.2
         version: 1.10.2(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(winston@3.17.0)
@@ -3019,8 +3022,8 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.1.0:
-    resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
+  lru-cache@11.2.1:
+    resolution: {integrity: sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==}
     engines: {node: 20 || >=22}
 
   luxon@3.6.1:
@@ -7353,7 +7356,7 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.1.0: {}
+  lru-cache@11.2.1: {}
 
   luxon@3.6.1: {}
 
@@ -8100,7 +8103,7 @@ snapshots:
 
   path-scurry@2.0.0:
     dependencies:
-      lru-cache: 11.1.0
+      lru-cache: 11.2.1
       minipass: 7.1.2
 
   path-to-regexp@6.3.0: {}

--- a/src/analytics/analytics.controller.ts
+++ b/src/analytics/analytics.controller.ts
@@ -1,0 +1,18 @@
+import { Body, Controller, Post, Get } from "@nestjs/common";
+import { type UtmEntry, UtmService } from "./utm.service";
+
+@Controller("analytics")
+export class AnalyticsController {
+  constructor(private readonly utmService: UtmService) {}
+
+  @Post("utm")
+  async addUtm(@Body() data: UtmEntry): Promise<string> {
+    this.utmService.add(data);
+    return "OK";
+  }
+
+  @Get("utm")
+  async getUtm(): Promise<string[]> {
+    return this.utmService.listToString();
+  }
+}

--- a/src/analytics/analytics.module.ts
+++ b/src/analytics/analytics.module.ts
@@ -1,0 +1,13 @@
+import { Global, Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
+import { UtmService } from "./utm.service";
+import { AnalyticsController } from "./analytics.controller";
+
+@Global()
+@Module({
+  imports: [ConfigModule],
+  providers: [UtmService],
+  controllers: [AnalyticsController],
+  exports: [UtmService],
+})
+export class AnalyticsModule {}

--- a/src/analytics/utm.service.ts
+++ b/src/analytics/utm.service.ts
@@ -1,0 +1,49 @@
+import { BadRequestException, Injectable, Logger } from "@nestjs/common";
+import { LRUCache } from "lru-cache";
+
+export type UtmEntry = {
+  ym_client_id: string;
+  utm: string;
+};
+
+@Injectable()
+export class UtmService {
+  private readonly logger = new Logger(UtmService.name);
+  private cache: LRUCache<string, string>;
+
+  constructor() {
+    this.cache = new LRUCache<string, string>({ max: 1000 });
+  }
+
+  add(entry: UtmEntry): void {
+    if (!entry?.ym_client_id || !entry?.utm) throw new BadRequestException("Bad post body");
+    this.cache.set(entry.ym_client_id, entry.utm);
+    this.logger.log(`UTM added: ${entry.ym_client_id}: ${entry.utm}`);
+  }
+
+  has(ym_client_id: string): boolean {
+    if (!ym_client_id) return false;
+    return this.cache.has(ym_client_id);
+  }
+
+  get(ym_client_id: string): string | undefined {
+    if (!ym_client_id) return undefined;
+    return this.cache.get(ym_client_id);
+  }
+
+  delete(ym_client_id: string): void {
+    if (!ym_client_id) return;
+    this.cache.delete(ym_client_id);
+    this.logger.log(`UTM deleted: ${ym_client_id}`);
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+
+  listToString(): string[] {
+    const utms: string[] = [];
+    this.cache.forEach((value, key) => utms.push(`${key}: ${value}`));
+    return utms;
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,7 @@ import { PostModule } from "./post/post.module";
 import { ServeStaticModule } from "@nestjs/serve-static";
 import { TildaModule } from "./tilda/tilda.module";
 import { resolve } from "path";
+import { AnalyticsModule } from "./analytics/analytics.module";
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { resolve } from "path";
       isGlobal: true,
     }),
     TildaModule,
+    AnalyticsModule,
     TelegramModule,
     CronModule,
     MailModule,


### PR DESCRIPTION
Добавлен модуль для анатитики, имплементирован сервис кэширования UTM меток.

Добавление UTM - POST `/analytics/utm`, в теле запроса json:
```ts
{
  ym_client_id: string;
  utm: string;
}
```

Получение всего списка закэшированных UTM - GET  `/analytics/utm`